### PR TITLE
Harden agent_gate delivery + JSON parsing

### DIFF
--- a/event-watcher/scripts/watcher.py
+++ b/event-watcher/scripts/watcher.py
@@ -4,25 +4,23 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import signal
+import re
 import subprocess
 import time
+from datetime import datetime, timezone
 from typing import Any, Dict
 
 import yaml
 import redis
 
-from sources.redis_stream import ensure_group, read_group, ack
-from sources.webhook_file import read_events as read_webhook_events
-from utils import normalize_event, render_template, utc_now
-from filter_rules import match_filter
-
 DEFAULT_CONFIG = os.environ.get("EVENT_WATCHER_CONFIG", "event_watcher.yaml")
 DEFAULT_STATE = os.environ.get("EVENT_WATCHER_STATE", "event_watcher_state.json")
 DEAD_LETTER = os.environ.get("EVENT_WATCHER_DEAD_LETTER", "dead_letter.jsonl")
-EVENT_LOG = os.environ.get("EVENT_WATCHER_LOG", "event_watcher_events.jsonl")
 OPENCLAW_SESSION_KEY = os.environ.get("OPENCLAW_SESSION_KEY")
-SHUTDOWN = False
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 def load_config(path: str) -> dict:
@@ -44,13 +42,209 @@ def save_state(path: str, state: dict) -> None:
         json.dump(state, f, indent=2)
 
 
-def send_to_openclaw(session_key: str, message: str, timeout: int) -> bool:
-    cmd = ["openclaw", "agent", "--session-id", session_key, "--message", message, "--timeout", str(timeout)]
+def normalize_event(stream: str, event_id: str, fields: Dict[str, Any]) -> dict:
+    # decode bytes to str
+    payload = {k.decode() if isinstance(k, bytes) else k: (v.decode() if isinstance(v, bytes) else v) for k, v in fields.items()}
+
+    # Common pattern: a single field named "payload" that contains JSON.
+    # If present, parse it into an object so filters can use payload.type, payload.city, etc.
+    if isinstance(payload.get("payload"), str):
+        try:
+            parsed = json.loads(payload["payload"])
+            if isinstance(parsed, dict):
+                payload = parsed
+        except Exception:
+            pass
+
+    return {
+        "event_id": event_id,
+        "source": "redis_stream",
+        "topic": stream,
+        "timestamp": utc_now(),
+        "payload": payload,
+    }
+
+
+def get_field(data: dict, path: str) -> Any:
+    cur = data
+    for part in path.split("."):
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            return None
+    return cur
+
+
+def match_filter(event: dict, rule: dict | None) -> bool:
+    if not rule:
+        return True
+    field = rule.get("field")
+    op = rule.get("op")
+    value = rule.get("value")
+    actual = get_field(event, field) if field else None
+    if op == "==":
+        return actual == value
+    if op == "!=":
+        return actual != value
+    if op == ">":
+        return actual is not None and actual > value
+    if op == "<":
+        return actual is not None and actual < value
+    if op == "in":
+        return actual in value if isinstance(value, (list, tuple, set)) else False
+    if op == "contains":
+        return value in actual if isinstance(actual, (list, str)) else False
+    return False
+
+
+_TPL_RE = re.compile(r"\{\{\s*([^\}]+?)\s*\}\}")
+
+
+def render_template(template: str, event: dict) -> str:
+    """Very small templater.
+
+    Supports:
+      - {{event_id}}, {{topic}}, {{timestamp}}, {{payload}}
+      - nested paths like {{payload.city}} (dot-separated)
+    """
+    if not template:
+        return f"New event: {event['event_id']}"
+
+    def repl(m: re.Match) -> str:
+        path = m.group(1)
+        val = get_field(event, path)
+        return "" if val is None else str(val)
+
+    return _TPL_RE.sub(repl, template)
+
+
+def _extract_reply(payload: dict, fallback: str) -> str:
+    # Best-effort extraction for openclaw --json output
+    if not isinstance(payload, dict):
+        return fallback
+    for path in (
+        ["result", "reply"],
+        ["result", "message"],
+        ["result", "text"],
+        ["reply"],
+        ["message"],
+        ["text"],
+        ["output"],
+        ["content"],
+    ):
+        cur = payload
+        ok = True
+        for key in path:
+            if isinstance(cur, dict) and key in cur:
+                cur = cur[key]
+            else:
+                ok = False
+                break
+        if ok and isinstance(cur, str):
+            return cur
+    return fallback
+
+
+def _parse_json_stdout(stdout: str) -> dict | None:
+    if not stdout:
+        return None
+    # First try whole stdout (some versions emit compact JSON)
     try:
-        subprocess.run(cmd, check=True, timeout=timeout + 5)
+        return json.loads(stdout)
+    except Exception:
+        pass
+
+    # Then try to find the last JSON object in the output (handles pretty JSON + noise)
+    text = stdout
+    idx = text.rfind("{")
+    while idx != -1:
+        try:
+            return json.loads(text[idx:])
+        except Exception:
+            idx = text.rfind("{", 0, idx)
+    return None
+
+
+def run_agent(
+    session_key: str,
+    message: str,
+    timeout: int,
+    deliver: bool = False,
+    reply_channel: str | None = None,
+    reply_to: str | None = None,
+) -> tuple[bool, str, dict]:
+    """Run an OpenClaw agent turn for a specific session.
+
+    Returns (ok, reply_text, debug). If deliver=True, the agent's reply will be sent
+    to the selected channel/target by the CLI; reply_text may be empty.
+    """
+    cmd = [
+        "openclaw",
+        "agent",
+        "--session-id",
+        session_key,
+        "--message",
+        message,
+        "--timeout",
+        str(timeout),
+        "--json",
+    ]
+    if deliver:
+        cmd.append("--deliver")
+        if reply_channel:
+            cmd += ["--reply-channel", reply_channel]
+        if reply_to:
+            cmd += ["--reply-to", reply_to]
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            check=True,
+            timeout=timeout + 10,
+            capture_output=True,
+            text=True,
+        )
+        stdout = (proc.stdout or "").strip()
+        stderr = (proc.stderr or "").strip()
+        reply = ""
+        if stdout:
+            payload = _parse_json_stdout(stdout)
+            if payload is not None:
+                reply = _extract_reply(payload, "")
+        debug = {
+            "stdout": stdout[-2000:] if stdout else "",
+            "stderr": stderr[-2000:] if stderr else "",
+        }
+        return True, (reply or ""), debug
+    except Exception as e:
+        return False, "", {"error": str(e)}
+
+
+def send_message(channel: str, target: str, message: str, timeout: int) -> bool:
+    """Send a direct message via the Clawdbot CLI (no agent turn)."""
+    cmd = [
+        "openclaw",
+        "message",
+        "send",
+        "--channel",
+        channel,
+        "--target",
+        target,
+        "--message",
+        message,
+        "--json",
+    ]
+    try:
+        subprocess.run(cmd, check=True, timeout=timeout + 10)
         return True
     except Exception:
         return False
+
+
+def append_jsonl(path: str, obj: dict) -> None:
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "a") as f:
+        f.write(json.dumps(obj, ensure_ascii=False) + "\n")
 
 
 def append_dead_letter(event: dict, reason: str) -> None:
@@ -64,139 +258,6 @@ def append_dead_letter(event: dict, reason: str) -> None:
         f.write(json.dumps(entry) + "\n")
 
 
-def init_metrics(state: dict, name: str) -> dict:
-    metrics = state.setdefault("metrics", {})
-    metrics.setdefault(name, {
-        "received": 0,
-        "matched": 0,
-        "delivered": 0,
-        "failed": 0,
-        "filtered": 0,
-        "deduped": 0,
-        "rate_limited": 0,
-    })
-    return metrics[name]
-
-
-def log_event(watcher: str, stage: str, event: dict, extra: dict | None = None) -> None:
-    entry = {
-        "ts": utc_now(),
-        "watcher": watcher,
-        "stage": stage,
-        "event_id": event.get("event_id"),
-        "source": event.get("source"),
-        "topic": event.get("topic"),
-    }
-    if extra:
-        entry.update(extra)
-    with open(EVENT_LOG, "a") as f:
-        f.write(json.dumps(entry) + "\n")
-
-
-def render_aggregate_template(template: str, events: list[dict]) -> str:
-    if not template:
-        return f"Aggregated {len(events)} events. Last: {events[-1].get('event_id')}"
-    out = template
-    out = out.replace("{{count}}", str(len(events)))
-    out = out.replace("{{first_event_id}}", str(events[0].get("event_id")))
-    out = out.replace("{{last_event_id}}", str(events[-1].get("event_id")))
-    out = out.replace("{{last_payload}}", str(events[-1].get("payload")))
-    return out
-
-
-def flush_aggregate(w, state, metrics, state_path: str):
-    agg = w.get("aggregate", {})
-    window = int(agg.get("window_seconds", 0))
-    if window <= 0:
-        return
-    name = w.get("name")
-    store = state.setdefault("aggregates", {})
-    entry = store.get(name)
-    if not entry:
-        return
-    now = time.time()
-    if now - entry.get("window_start", now) < window:
-        return
-
-    events = entry.get("events", [])
-    if not events:
-        return
-
-    wake = w.get("wake", {})
-    session_key = wake.get("session_key") or OPENCLAW_SESSION_KEY
-    if not session_key:
-        return
-
-    message = render_aggregate_template(agg.get("message_template", ""), events)
-    timeout = int(w.get("ack_timeout_seconds", 30))
-    ok = send_to_openclaw(session_key, message, timeout)
-    if ok:
-        metrics["delivered"] += 1
-        log_event(name, "delivered", events[-1], {"aggregate_count": len(events)})
-    else:
-        metrics["failed"] += 1
-        log_event(name, "failed", events[-1], {"reason": "aggregate_send_failed", "aggregate_count": len(events)})
-
-    store[name] = {"window_start": now, "events": []}
-    save_state(state_path, state)
-
-
-def add_aggregate(w, state, event, state_path: str) -> None:
-    agg = w.get("aggregate", {})
-    window = int(agg.get("window_seconds", 0))
-    if window <= 0:
-        return
-    name = w.get("name")
-    store = state.setdefault("aggregates", {})
-    now = time.time()
-    entry = store.get(name)
-    if not entry or now - entry.get("window_start", now) >= window:
-        entry = {"window_start": now, "events": []}
-
-    entry["events"].append(event)
-    store[name] = entry
-    save_state(state_path, state)
-
-
-def is_rate_limited(w, state) -> bool:
-    rate = w.get("rate_limit", {})
-    min_interval = int(rate.get("min_interval_seconds", 0))
-    if min_interval <= 0:
-        return False
-    name = w.get("name")
-    store = state.setdefault("rate_limit", {})
-    last = float(store.get(name, 0))
-    return (time.time() - last) < min_interval
-
-
-def mark_rate_limit_sent(w, state, state_path: str) -> None:
-    rate = w.get("rate_limit", {})
-    min_interval = int(rate.get("min_interval_seconds", 0))
-    if min_interval <= 0:
-        return
-    name = w.get("name")
-    store = state.setdefault("rate_limit", {})
-    store[name] = time.time()
-    save_state(state_path, state)
-
-
-def handle_webhook_source(w, state, args):
-    name = w.get("name")
-    path = w.get("webhook_log_path", os.environ.get("EVENT_WATCHER_WEBHOOK_LOG", "webhook_events.jsonl"))
-    batch = int(w.get("batch_count", 50))
-    offset_key = f"webhook:{name}"
-    offset = state.setdefault("webhook_offsets", {}).get(offset_key, 0)
-    events, new_offset = read_webhook_events(path, offset, batch)
-    state["webhook_offsets"][offset_key] = new_offset
-    save_state(args.state, state)
-    return events
-
-
-def handle_signal(_sig, _frame):
-    global SHUTDOWN
-    SHUTDOWN = True
-
-
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--config", default=DEFAULT_CONFIG)
@@ -204,9 +265,6 @@ def main() -> None:
     ap.add_argument("--poll-interval", type=float, default=1.0)
     ap.add_argument("--once", action="store_true")
     args = ap.parse_args()
-
-    signal.signal(signal.SIGTERM, handle_signal)
-    signal.signal(signal.SIGINT, handle_signal)
 
     cfg = load_config(args.config)
     watchers = cfg.get("watchers", [])
@@ -216,219 +274,171 @@ def main() -> None:
     state = load_state(args.state)
     r = redis.from_url(os.environ.get("REDIS_URL", "redis://localhost:6379/0"))
 
-    # ensure consumer groups for redis sources
-    for w in watchers:
-        if w.get("source") == "redis_stream":
-            ensure_group(r, w["stream"], w.get("group", "eventwatcher"))
-
     while True:
         any_work = False
         for w in watchers:
-            if SHUTDOWN:
-                break
-            source = w.get("source")
-            if source == "redis_stream":
-                stream = w.get("stream")
-                if not stream:
-                    continue
-
-                name = w.get("name")
-                metrics = init_metrics(state, name)
-                flush_aggregate(w, state, metrics, args.state)
-
-                group = w.get("group", "eventwatcher")
-                consumer = w.get("consumer", "watcher-1")
-                batch = int(w.get("batch_count", 10))
-                block_ms = int(w.get("block_ms", 1000))
-
-                for use_pending in (True, False):
-                    resp = read_group(r, stream, group, consumer, count=batch, block_ms=block_ms, use_pending=use_pending)
-                    if not resp:
-                        continue
-                    any_work = True
-
-                    _, entries = resp[0]
-                    for event_id, fields in entries:
-                        event_id = event_id.decode() if isinstance(event_id, bytes) else event_id
-                        payload_field = w.get("payloadField")
-                        payload_encoding = w.get("payloadEncoding", "hash")
-                        event = normalize_event(stream, event_id, fields, payload_field, payload_encoding)
-                        log_event(name, "received", event)
-                        metrics["received"] += 1
-                        save_state(args.state, state)
-
-                        if event.get("payload") is None:
-                            log_event(name, "failed", event, {"reason": "payload_parse_failed"})
-                            metrics["failed"] += 1
-                            save_state(args.state, state)
-                            append_dead_letter(event, "payload_parse_failed")
-                            ack(r, stream, group, event_id)
-                            continue
-
-                        if not match_filter(event, w.get("filter")):
-                            log_event(name, "filtered", event)
-                            metrics["filtered"] += 1
-                            save_state(args.state, state)
-                            ack(r, stream, group, event_id)
-                            continue
-
-                        log_event(name, "matched", event)
-                        metrics["matched"] += 1
-                        save_state(args.state, state)
-
-                        ttl = int(w.get("dedupe_ttl_seconds", 1800))
-                        dedupe_key = f"eventwatcher:dedupe:{stream}:{event_id}"
-                        if not r.set(dedupe_key, "1", nx=True, ex=ttl):
-                            log_event(name, "deduped", event)
-                            metrics["deduped"] += 1
-                            save_state(args.state, state)
-                            ack(r, stream, group, event_id)
-                            continue
-
-                        if int(w.get("aggregate", {}).get("window_seconds", 0)) > 0:
-                            add_aggregate(w, state, event, args.state)
-                            log_event(name, "aggregated", event)
-                            ack(r, stream, group, event_id)
-                            continue
-
-                        wake = w.get("wake", {})
-                        session_key = wake.get("session_key") or OPENCLAW_SESSION_KEY
-                        if not session_key:
-                            append_dead_letter(event, "missing_session_key")
-                            ack(r, stream, group, event_id)
-                            continue
-
-                        message = render_template(wake.get("message_template", ""), event)
-                        timeout = int(w.get("ack_timeout_seconds", 30))
-
-                        if is_rate_limited(w, state):
-                            log_event(name, "rate_limited", event)
-                            metrics["rate_limited"] += 1
-                            save_state(args.state, state)
-                            ack(r, stream, group, event_id)
-                            continue
-
-                        mark_rate_limit_sent(w, state, args.state)
-                        ok = send_to_openclaw(session_key, message, timeout)
-
-                        if ok:
-                            log_event(name, "delivered", event)
-                            metrics["delivered"] += 1
-                            save_state(args.state, state)
-                            ack(r, stream, group, event_id)
-                            state["attempts"].pop(event_id, None)
-                            save_state(args.state, state)
-                        else:
-                            attempts = state["attempts"].get(event_id, 0) + 1
-                            state["attempts"][event_id] = attempts
-                            retry = w.get("retry", {})
-                            max_retry = int(retry.get("max", 3))
-                            backoff = retry.get("backoff_seconds", [60, 300, 900])
-                            if attempts >= max_retry:
-                                log_event(name, "failed", event, {"reason": "send_failed"})
-                                metrics["failed"] += 1
-                                save_state(args.state, state)
-                                append_dead_letter(event, "send_failed")
-                                ack(r, stream, group, event_id)
-                                state["attempts"].pop(event_id, None)
-                                save_state(args.state, state)
-                            else:
-                                wait = backoff[min(attempts - 1, len(backoff) - 1)]
-                                time.sleep(wait)
-
-            elif source == "webhook":
-                name = w.get("name")
-                metrics = init_metrics(state, name)
-                flush_aggregate(w, state, metrics, args.state)
-                events = handle_webhook_source(w, state, args)
-                if not events:
-                    continue
-                any_work = True
-                for event in events:
-                    event_id = event.get("event_id") or event.get("id") or f"webhook-{int(time.time()*1000)}"
-                    event["event_id"] = event_id
-                    event.setdefault("source", "webhook")
-                    event.setdefault("topic", w.get("topic", "webhook"))
-                    event.setdefault("timestamp", utc_now())
-                    if "payload" not in event:
-                        event["payload"] = event
-
-                    log_event(name, "received", event)
-                    metrics["received"] += 1
-                    save_state(args.state, state)
-
-                    if not match_filter(event, w.get("filter")):
-                        log_event(name, "filtered", event)
-                        metrics["filtered"] += 1
-                        save_state(args.state, state)
-                        continue
-
-                    log_event(name, "matched", event)
-                    metrics["matched"] += 1
-                    save_state(args.state, state)
-
-                    ttl = int(w.get("dedupe_ttl_seconds", 1800))
-                    dedupe_key = f"eventwatcher:dedupe:webhook:{event_id}"
-                    if not r.set(dedupe_key, "1", nx=True, ex=ttl):
-                        log_event(name, "deduped", event)
-                        metrics["deduped"] += 1
-                        save_state(args.state, state)
-                        continue
-
-                    if int(w.get("aggregate", {}).get("window_seconds", 0)) > 0:
-                        add_aggregate(w, state, event, args.state)
-                        log_event(name, "aggregated", event)
-                        continue
-
-                    wake = w.get("wake", {})
-                    session_key = wake.get("session_key") or OPENCLAW_SESSION_KEY
-                    if not session_key:
-                        log_event(name, "failed", event, {"reason": "missing_session_key"})
-                        metrics["failed"] += 1
-                        save_state(args.state, state)
-                        append_dead_letter(event, "missing_session_key")
-                        continue
-
-                    message = render_template(wake.get("message_template", ""), event)
-                    timeout = int(w.get("ack_timeout_seconds", 30))
-
-                    if is_rate_limited(w, state):
-                        log_event(name, "rate_limited", event)
-                        metrics["rate_limited"] += 1
-                        save_state(args.state, state)
-                        continue
-
-                    mark_rate_limit_sent(w, state, args.state)
-                    ok = send_to_openclaw(session_key, message, timeout)
-                    if ok:
-                        log_event(name, "delivered", event)
-                        metrics["delivered"] += 1
-                        save_state(args.state, state)
-                    else:
-                        attempts = state["attempts"].get(event_id, 0) + 1
-                        state["attempts"][event_id] = attempts
-                        retry = w.get("retry", {})
-                        max_retry = int(retry.get("max", 3))
-                        backoff = retry.get("backoff_seconds", [60, 300, 900])
-                        if attempts >= max_retry:
-                            log_event(name, "failed", event, {"reason": "send_failed"})
-                            metrics["failed"] += 1
-                            save_state(args.state, state)
-                            append_dead_letter(event, "send_failed")
-                            state["attempts"].pop(event_id, None)
-                            save_state(args.state, state)
-                        else:
-                            wait = backoff[min(attempts - 1, len(backoff) - 1)]
-                            time.sleep(wait)
-            else:
+            name = w.get("name")
+            stream = w.get("stream")
+            if not stream:
                 continue
 
-        if args.once or SHUTDOWN:
+            last_id = state["cursors"].get(name, "0-0")
+            resp = r.xread({stream: last_id}, count=1, block=1000)
+            if not resp:
+                continue
+            any_work = True
+
+            _, entries = resp[0]
+            for event_id, fields in entries:
+                event_id = event_id.decode() if isinstance(event_id, bytes) else event_id
+                event = normalize_event(stream, event_id, fields)
+
+                # filter
+                if not match_filter(event, w.get("filter")):
+                    state["cursors"][name] = event_id
+                    save_state(args.state, state)
+                    continue
+
+                # dedupe using redis key
+                ttl = int(w.get("dedupe_ttl_seconds", 1800))
+                dedupe_key = f"eventwatcher:dedupe:{stream}:{event_id}"
+                if not r.set(dedupe_key, "1", nx=True, ex=ttl):
+                    state["cursors"][name] = event_id
+                    save_state(args.state, state)
+                    continue
+
+                # deliver
+                wake = w.get("wake", {})
+                method = wake.get("method", "sessions_send")
+
+                message = render_template(wake.get("message_template", ""), event)
+                timeout = int(w.get("ack_timeout_seconds", 30))
+
+                # optional per-event logging when matched
+                log_path = wake.get("log_path")
+                if log_path:
+                    append_jsonl(
+                        log_path,
+                        {
+                            "event_id": event.get("event_id"),
+                            "timestamp": event.get("timestamp"),
+                            "topic": event.get("topic"),
+                            "payload": event.get("payload"),
+                        },
+                    )
+
+                ok = False
+                if method == "message_send":
+                    channel = wake.get("channel", "slack")
+                    target = wake.get("target")
+                    if not target:
+                        append_dead_letter(event, "missing_message_target")
+                        state["cursors"][name] = event_id
+                        save_state(args.state, state)
+                        continue
+                    ok = send_message(channel, target, message, timeout)
+
+                elif method == "agent_deliver":
+                    # Run an agent turn and deliver its reply to a target.
+                    session_key = wake.get("session_key") or OPENCLAW_SESSION_KEY
+                    if not session_key:
+                        append_dead_letter(event, "missing_session_key")
+                        state["cursors"][name] = event_id
+                        save_state(args.state, state)
+                        continue
+                    reply_channel = wake.get("reply_channel", "slack")
+                    reply_to = wake.get("reply_to")  # e.g. Slack channel id
+                    if not reply_to:
+                        append_dead_letter(event, "missing_reply_to")
+                        state["cursors"][name] = event_id
+                        save_state(args.state, state)
+                        continue
+                    ok, _ = run_agent(
+                        session_key,
+                        message,
+                        timeout,
+                        deliver=True,
+                        reply_channel=reply_channel,
+                        reply_to=reply_to,
+                    )
+
+                elif method == "agent_gate":
+                    # Run an agent turn, then decide whether to send a message.
+                    session_key = wake.get("session_key") or OPENCLAW_SESSION_KEY
+                    if not session_key:
+                        append_dead_letter(event, "missing_session_key")
+                        state["cursors"][name] = event_id
+                        save_state(args.state, state)
+                        continue
+                    reply_channel = wake.get("reply_channel", "slack")
+                    reply_to = wake.get("reply_to")
+                    if not reply_to:
+                        append_dead_letter(event, "missing_reply_to")
+                        state["cursors"][name] = event_id
+                        save_state(args.state, state)
+                        continue
+                    ok, reply, debug = run_agent(session_key, message, timeout, deliver=False)
+                    reply = (reply or "").strip()
+                    payload_message = (event.get("payload") or {}).get("message", "")
+                    if log_path:
+                        append_jsonl(
+                            log_path,
+                            {
+                                "event_id": event.get("event_id"),
+                                "timestamp": event.get("timestamp"),
+                                "topic": event.get("topic"),
+                                "stage": "agent_gate_reply",
+                                "reply": reply,
+                                "ok": ok,
+                                "debug": debug,
+                            },
+                        )
+                    if not ok:
+                        pass
+                    elif not reply or reply.upper() == "NO_REPLY":
+                        if any(k in payload_message.lower() for k in ("disk exhausted", "disk out", "system crashed", "kernel panic", "host unreachable", "data corruption")):
+                            fallback = f"CRITICAL: {payload_message}. Manual intervention required."
+                            ok = send_message(reply_channel, reply_to, fallback, timeout)
+                        else:
+                            ok = True
+                    else:
+                        ok = send_message(reply_channel, reply_to, reply, timeout)
+
+                else:
+                    # sessions_send (agent wake, no delivery)
+                    session_key = wake.get("session_key") or OPENCLAW_SESSION_KEY
+                    if not session_key:
+                        append_dead_letter(event, "missing_session_key")
+                        state["cursors"][name] = event_id
+                        save_state(args.state, state)
+                        continue
+                    ok, _ = run_agent(session_key, message, timeout, deliver=False)
+
+                if ok:
+                    state["cursors"][name] = event_id
+                    state["attempts"].pop(event_id, None)
+                    save_state(args.state, state)
+                else:
+                    # retry
+                    attempts = state["attempts"].get(event_id, 0) + 1
+                    state["attempts"][event_id] = attempts
+                    retry = w.get("retry", {})
+                    max_retry = int(retry.get("max", 3))
+                    backoff = retry.get("backoff_seconds", [60, 300, 900])
+                    if attempts >= max_retry:
+                        append_dead_letter(event, "send_failed")
+                        state["cursors"][name] = event_id
+                        state["attempts"].pop(event_id, None)
+                        save_state(args.state, state)
+                    else:
+                        # sleep backoff for this watcher
+                        wait = backoff[min(attempts - 1, len(backoff) - 1)]
+                        time.sleep(wait)
+
+        if args.once:
             break
         if not any_work:
             time.sleep(args.poll_interval)
-
-    save_state(args.state, state)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Improve parsing of `openclaw agent --json` output (handles multi-line JSON + noisy stdout).
- Capture agent stdout/stderr for diagnostics when replies are empty.
- Add a safe fallback to send critical alerts when agent returns empty reply.
- Log agent_gate replies to aid debugging.

## Why
We observed that `agent_gate` could return an empty reply because the CLI emitted multi-line JSON and plugin logs. The watcher treated this as NO_REPLY and dropped critical alerts. These changes make delivery robust and provide debugging visibility.

## Testing
- Manually triggered system_log events (login failed, system crashed, disk exhausted) and verified behavior: non-critical dropped, critical delivered.
