### PR TITLE
feat: nested template paths

### DIFF
--- a/event-watcher/scripts/utils.py
+++ b/event-watcher/scripts/utils.py
@@ -77,6 +77,24 @@ def render_template(template: str, event: dict) -> str:
     if not template:
         return f"New event: {event['event_id']}"
     out = template
-    for key in ["event_id", "source", "topic", "timestamp", "payload"]:
-        out = out.replace(f"{{{{{key}}}}}", str(event.get(key)))
-    return out
+
+    # Support nested paths like {{payload.city}}
+    def lookup(path: str):
+        cur = event
+        for part in path.split("."):
+            if isinstance(cur, dict) and part in cur:
+                cur = cur[part]
+            else:
+                return None
+        return cur
+
+    # Replace {{path}} patterns
+    import re
+    pattern = re.compile(r"\{\{\s*([^\}]+?)\s*\}\}")
+
+    def repl(match):
+        key = match.group(1).strip()
+        val = lookup(key)
+        return "" if val is None else str(val)
+
+    return pattern.sub(repl, out)

--- a/event-watcher/tests/test_template_render.py
+++ b/event-watcher/tests/test_template_render.py
@@ -1,0 +1,20 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scripts.utils import render_template
+
+
+def test_nested_template():
+    event = {
+        "event_id": "1",
+        "payload": {"city": "beijing", "temp": 5},
+    }
+    out = render_template("City={{payload.city}} Temp={{payload.temp}}", event)
+    assert out == "City=beijing Temp=5"
+
+
+def test_unknown_path():
+    event = {"event_id": "1", "payload": {"city": "beijing"}}
+    out = render_template("X={{payload.zip}}", event)
+    assert out == "X="


### PR DESCRIPTION
## Summary\n- Support {{payload.city}}-style nested template paths\n- Add tests\n\n## Testing\n- python3 -m pytest -q event-watcher/tests/test_template_render.py